### PR TITLE
Numeric check in TokenValueInput

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/stems",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/stems",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "The Audius React component library",
   "author": "",
   "license": "",

--- a/src/TokenValueInput/TokenValueInput.tsx
+++ b/src/TokenValueInput/TokenValueInput.tsx
@@ -42,7 +42,7 @@ const TokenValueInput: React.FC<TokenValueInputProps> = ({
     (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
       let value = e.target.value
       if (isNumeric) {
-        value = value.replace(/,/g, '')
+        value = value.replace(/[^0-9.]+/g, '')
       }
       setInputValue(value)
       if (onChange) onChange(value)


### PR DESCRIPTION
Disables inputs for `isNumeric` from anything outside of 0-9 and .