### PR TITLE
Rework modal to support all client use cases

### DIFF
--- a/src/Modal/Modal.module.css
+++ b/src/Modal/Modal.module.css
@@ -1,4 +1,4 @@
-:global(#bgModal) {
+:global(.bgModal) {
   background-color: rgba(0, 0, 0, 0.6);
   z-index: 9999;
   position: fixed;
@@ -10,7 +10,7 @@
   height: 100vh;
 }
 
-:global(#bgModal):global(.bgModalVisible) {
+:global(.bgModal):global(.bgModalVisible) {
   overflow: hidden;
   pointer-events: all;
   opacity: 1;
@@ -29,7 +29,7 @@
   height: auto !important;
 }
 
-:global(#modalRootContainer) {
+:global(.modalRootContainer) {
   /* This needs to position `absolute` instead of `fixed` (which is what it should be)
    * due to this utterly absurd webkit iOS bug:
    * https://gist.github.com/avesus/957889b4941239490c6c441adbe32398

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -166,7 +166,9 @@ const Modal = ({
         const modalElement = findAncestor(e, `.${wrapperClass}`)
         if (!modalElement) return false
         const isModalWrapper = modalElement.classList.contains(wrapperClass)
-        const isThisModalWrapper = modalElement.classList.contains(`${wrapperClass}-${id}`)
+        const isThisModalWrapper = modalElement.classList.contains(
+          `${wrapperClass}-${id}`
+        )
         return isModalWrapper && !isThisModalWrapper
       }
       return false

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react'
+import React, { useEffect, useState, useCallback, useMemo } from 'react'
 import ReactDOM from 'react-dom'
 import uniqueId from 'lodash/uniqueId'
 
@@ -13,6 +13,7 @@ import useHotkeys from 'hooks/useHotKeys'
 import useClickOutside from 'hooks/useClickOutside'
 import useScrollLock from 'hooks/useScrollLock'
 import { useModalScrollCount } from './hooks'
+import findAncestor from 'utils/findAncestor'
 
 const rootContainer = 'modalRootContainer'
 const rootId = 'modalRoot'
@@ -103,7 +104,7 @@ const Modal = ({
   showDismissButton = false,
   zIndex
 }: ModalProps) => {
-  const [id] = useState(modalKey || uniqueId('modal-'))
+  const id = useMemo(() => modalKey || uniqueId('modal-'), [modalKey])
   const onTouchMove = useCallback(
     (e: any) => {
       !allowScroll && e.preventDefault()
@@ -162,11 +163,10 @@ const Modal = ({
     // dismiss it.
     (e: EventTarget) => {
       if (e instanceof HTMLElement) {
-        const isModalWrapper = e.classList.contains(wrapperClass)
-        const isThisModalWrapper = e.classList.contains(`${wrapperClass}-${id}`)
-        if (isModalWrapper && !isThisModalWrapper) {
-          return true
-        }
+        const modalElement = findAncestor(e, `.${wrapperClass}`)
+        const isModalWrapper = modalElement.classList.contains(wrapperClass)
+        const isThisModalWrapper = modalElement.classList.contains(`${wrapperClass}-${id}`)
+        return isModalWrapper && !isThisModalWrapper
       }
       return false
     }

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -164,6 +164,7 @@ const Modal = ({
     (e: EventTarget) => {
       if (e instanceof HTMLElement) {
         const modalElement = findAncestor(e, `.${wrapperClass}`)
+        if (!modalElement) return false
         const isModalWrapper = modalElement.classList.contains(wrapperClass)
         const isThisModalWrapper = modalElement.classList.contains(`${wrapperClass}-${id}`)
         return isModalWrapper && !isThisModalWrapper

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -11,6 +11,7 @@ import { IconRemove } from 'Icons'
 import useHotkeys from 'hooks/useHotKeys'
 import useClickOutside from 'hooks/useClickOutside'
 import useScrollLock from 'hooks/useScrollLock'
+import { useModalScrollCount } from './hooks'
 
 const rootContainer = 'modalRootContainer'
 const rootId = 'modalRoot'
@@ -81,8 +82,6 @@ const Modal = ({
   titleClassName,
   subtitleClassName,
   headerContainerClassName,
-  incrementScrollCount,
-  decrementScrollCount,
   anchor = Anchor.CENTER,
   subtitle,
   verticalAnchorOffset = 0,
@@ -105,6 +104,7 @@ const Modal = ({
   const [modalRoot, bgModal] = useModalRoot(zIndex)
   const [isDestroyed, setIsDestroyed] = useState(isOpen)
 
+  const { incrementScrollCount, decrementScrollCount } = useModalScrollCount()
   useScrollLock(isDestroyed, incrementScrollCount, decrementScrollCount)
   useEffect(() => {
     if (isOpen) setIsDestroyed(true)

--- a/src/Modal/hooks.ts
+++ b/src/Modal/hooks.ts
@@ -1,3 +1,4 @@
+import useGlobal from 'hooks/useGlobal'
 import { useCallback, useEffect, useState } from 'react'
 
 export const setOverflowHidden = () => {
@@ -16,18 +17,18 @@ export const setModalRootTop = () => {
 }
 
 export const useModalScrollCount = () => {
-  const [count, setCount] = useState(0)
+  const [getCount, setCount] = useGlobal('modal-scroll-count', 0)
   const [isOverflowHidden, setIsOverflowHidden] = useState(false)
   useEffect(() => {
-    if (!isOverflowHidden && count > 0) {
+    if (!isOverflowHidden && getCount() > 0) {
       setIsOverflowHidden(true)
       setOverflowHidden()
       setModalRootTop()
-    } else if (isOverflowHidden && count === 0) {
+    } else if (isOverflowHidden && getCount() === 0) {
       setIsOverflowHidden(false)
       removeOverflowHidden()
     }
-  }, [count, isOverflowHidden])
+  }, [getCount, isOverflowHidden])
 
   const incrementScrollCount = useCallback(() => setCount(count => count + 1), [
     setCount

--- a/src/Modal/hooks.ts
+++ b/src/Modal/hooks.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useState } from 'react'
+
+export const setOverflowHidden = () => {
+  document.body.setAttribute('style', 'overflow:hidden;')
+}
+
+export const removeOverflowHidden = () => {
+  document.body.setAttribute('style', '')
+}
+
+export const setModalRootTop = () => {
+  const root = document.getElementById('modalRootContainer')
+  if (root) {
+    root.setAttribute('style', `top: ${window.scrollY}px`)
+  }
+}
+
+export const useModalScrollCount = () => {
+  const [count, setCount] = useState(0)
+  const [isOverflowHidden, setIsOverflowHidden] = useState(false)
+  useEffect(() => {
+    if (!isOverflowHidden && count > 0) {
+      setIsOverflowHidden(true)
+      setOverflowHidden()
+      setModalRootTop()
+    } else if (isOverflowHidden && count === 0) {
+      setIsOverflowHidden(false)
+      removeOverflowHidden()
+    }
+  }, [count, isOverflowHidden])
+
+  const incrementScrollCount = useCallback(() => setCount(count => count + 1), [
+    setCount
+  ])
+  const decrementScrollCount = useCallback(() => setCount(count => count - 1), [
+    setCount
+  ])
+
+  return {
+    incrementScrollCount,
+    decrementScrollCount
+  }
+}

--- a/src/Modal/types.ts
+++ b/src/Modal/types.ts
@@ -36,12 +36,6 @@ export type ModalProps = {
 
   allowScroll?: boolean
 
-  // Increments the scroll count for scrollLock
-  incrementScrollCount: () => void
-
-  // Decrements the scroll count for scrollLock
-  decrementScrollCount: () => void
-
   // Classnames
 
   wrapperClassName?: string

--- a/src/Modal/types.ts
+++ b/src/Modal/types.ts
@@ -7,8 +7,26 @@ export enum Anchor {
 }
 
 export type ModalProps = {
+  /**
+   * Optional unique key to assign to the modal.
+   * If not provided, it is auto-generated.
+   */
+  modalKey?: string
+
+  /**
+   * Modal contents
+   */
   children: ReactNode
+
+  /**
+   * Callback to fire when the modal is closed
+   * Should set isOpen accordingly
+   */
   onClose: () => void
+
+  /**
+   * Whether or not the modal is open
+   */
   isOpen: boolean
 
   /**
@@ -30,7 +48,13 @@ export type ModalProps = {
   showDismissButton?: boolean
 
   /**
-   * Manually set z-index
+   * Manually set z-index.
+   *
+   * By default, the z-index is 10000 and the modal background shadow is
+   * set to z-index - 1 so that the modal appears on top of the shadow.
+   *
+   * If you would like to nest modals, it's important to increase the z-index by
+   * 2 for every modal so that the parent modal lives behind the child modal's shadow.
    */
   zIndex?: number
 

--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -5,15 +5,15 @@ import { useEffect, useRef } from 'react'
  * outside of the element referenced by the returned ref.
  *
  * @param onClick the callback fired when a click is performed "outside"
- * @param isException optional check to be run on the element that receives
- * the "click." If isException returns true, the click is not considered outside
+ * @param ignoreClick optional check to be run on the element that receives
+ * the "click." If ignoreClick returns true, the click is not considered outside
  * even if it was outside the element referenced.
   
  * @returns a ref that should be used to mark the "inside" element
  */
 const useClickOutside = (
   onClick: () => void,
-  isException: (target: EventTarget) => boolean = () => false
+  ignoreClick: (target: EventTarget) => boolean = () => false
 ) => {
   const ref = useRef(null)
 
@@ -22,7 +22,7 @@ const useClickOutside = (
       if (
         !ref.current ||
         (ref.current && ref.current.contains(e.target)) ||
-        isException(e.target)
+        ignoreClick(e.target)
       ) {
         return
       }
@@ -31,7 +31,7 @@ const useClickOutside = (
 
     document.addEventListener('mousedown', handleClick)
     return () => document.removeEventListener('mousedown', handleClick)
-  }, [onClick, isException])
+  }, [onClick, ignoreClick])
 
   return ref
 }

--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -4,22 +4,34 @@ import { useEffect, useRef } from 'react'
  * Custom hook that fires an onClick callback when the user clicks
  * outside of the element referenced by the returned ref.
  *
- * @param {function} onClick the callback fired when a click is performed "outside"
+ * @param onClick the callback fired when a click is performed "outside"
+ * @param isException optional check to be run on the element that receives
+ * the "click." If isException returns true, the click is not considered outside
+ * even if it was outside the element referenced.
+  
  * @returns a ref that should be used to mark the "inside" element
  */
-const useClickOutside = (onClick: () => void) => {
+const useClickOutside = (
+  onClick: () => void,
+  isException: (target: EventTarget) => boolean = () => false
+) => {
   const ref = useRef(null)
 
   useEffect(() => {
     const handleClick = (e: MouseEvent) => {
-      if (!ref.current || (ref.current && ref.current.contains(e.target)))
+      if (
+        !ref.current ||
+        (ref.current && ref.current.contains(e.target)) ||
+        isException(e.target)
+      ) {
         return
+      }
       onClick()
     }
 
     document.addEventListener('mousedown', handleClick)
     return () => document.removeEventListener('mousedown', handleClick)
-  }, [onClick])
+  }, [onClick, isException])
 
   return ref
 }

--- a/src/hooks/useGlobal.ts
+++ b/src/hooks/useGlobal.ts
@@ -1,0 +1,33 @@
+declare global {
+  interface Window {
+    AudiusStems: any
+  }
+}
+
+window.AudiusStems = window.AudiusStems || {}
+
+/**
+ * Hook to "share state" between components using the global window object.
+ * Obviously, comes with caveats with globals.
+ *
+ * @param name shared name between users of a useGlobal
+ * @param initialValue
+ * @returns getter, setter
+ *  Similar to useState, except the getter is a function and the
+ *  setter should only be invoked with a mutator function rather than a "new value"
+ */
+const useGlobal = <T>(
+  name: string,
+  initialValue: T
+): [() => T, (mutator: (cur: T) => void) => void] => {
+  window.AudiusStems[name] = initialValue
+
+  const getter = () => window.AudiusStems[name]
+  const setter = (mutator: (cur: T) => void) => {
+    window.AudiusStems[name] = mutator(window.AudiusStems[name])
+  }
+
+  return [getter, setter]
+}
+
+export default useGlobal

--- a/src/hooks/useGlobal.ts
+++ b/src/hooks/useGlobal.ts
@@ -1,3 +1,5 @@
+import { useEffect } from 'react'
+
 declare global {
   interface Window {
     AudiusStems: any
@@ -20,7 +22,9 @@ const useGlobal = <T>(
   name: string,
   initialValue: T
 ): [() => T, (mutator: (cur: T) => void) => void] => {
-  window.AudiusStems[name] = initialValue
+  useEffect(() => {
+    window.AudiusStems[name] = initialValue
+  }, [name, initialValue])
 
   const getter = () => window.AudiusStems[name]
   const setter = (mutator: (cur: T) => void) => {

--- a/src/utils/findAncestor.ts
+++ b/src/utils/findAncestor.ts
@@ -1,0 +1,19 @@
+/**
+ * Legacy browser support for `HTMLElement.closest`
+ * @param el
+ * @param selector query selector
+ */
+const findAncestor = (el: HTMLElement, selector: string) => {
+  if (el.closest) {
+    return el.closest(selector)
+  }
+  // Fall back to just looping back through parents
+  while (
+    (el = el.parentElement) &&
+    // @ts-ignore
+    !(el.matches || el.matchesSelector).call(el, selector)
+  );
+  return el
+}
+
+export default findAncestor


### PR DESCRIPTION
Reworks the modal to support use in protocol-dashboard & audius-client in all use cases. Those relevant PRs are:

audius-client: https://github.com/AudiusProject/audius-client/pull/125
protocol-dashboard: https://github.com/AudiusProject/protocol-dashboard/pull/16

There are three major changes in this PR:

1. Scroll counting is done internally within the modal now. Although this does break the "single counter" model that we share across the dapp to lock scroll count, I think it's ok for modals afaict. Once all the modals let go of their counter, scrolling is freed up. Works even with multiple modals.

2. Modals now create their own background / root context. One challenging issue I ran into when integrating this guy into all parts of the dapp is in cases where we have nested modals (e.g. stems modal inside edit track modal), the modals end up kind of canceling each other's backgrounds / root contexts out since they refer to the same dom node and both modals are mounted on the page at the same time. A unique `modalKey` similar to the scrubber pattern is added here (auto-assigned if not provided, but useful for debugging to provide).

3. Updates useClickOutside to respect an `isException` check. This is necessary to allow "useClickOutside" style dismisses to work in the case of nested modals. We never hit this issue in the dapp before because nested modals were always one antd modal and one stems modal so they never clashed in that sense.