### PR TITLE
Fix click outside bug in modal

### DIFF
--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -162,7 +162,7 @@ const Modal = ({
     // dismiss "this" modal. We let the useClickOutside in "that" modal to
     // dismiss it.
     (e: EventTarget) => {
-      if (e instanceof HTMLElement) {
+      if (e instanceof Element) {
         const modalElement = findAncestor(e, `.${wrapperClass}`)
         if (!modalElement) return false
         const isModalWrapper = modalElement.classList.contains(wrapperClass)

--- a/src/utils/findAncestor.ts
+++ b/src/utils/findAncestor.ts
@@ -1,9 +1,9 @@
 /**
- * Legacy browser support for `HTMLElement.closest`
+ * Legacy browser support for `Element.closest`
  * @param el
  * @param selector query selector
  */
-const findAncestor = (el: HTMLElement, selector: string) => {
+const findAncestor = (el: Element, selector: string) => {
   if (el.closest) {
     return el.closest(selector)
   }


### PR DESCRIPTION
The bug called out in 
https://github.com/AudiusProject/audius-client/pull/125#issuecomment-744749786

Is due to clicking on the "X" being a click on an SVG element rather than an HTML element. The solution is to switch the check for Element, which supports closest https://developer.mozilla.org/en-US/docs/Web/API/Element/closest