### PR TITLE
Use modal absolute position only on ios safari

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/stems",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/stems",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "The Audius React component library",
   "author": "",
   "license": "",

--- a/src/Modal/Modal.module.css
+++ b/src/Modal/Modal.module.css
@@ -30,11 +30,7 @@
 }
 
 :global(.modalRootContainer) {
-  /* This needs to position `absolute` instead of `fixed` (which is what it should be)
-   * due to this utterly absurd webkit iOS bug:
-   * https://gist.github.com/avesus/957889b4941239490c6c441adbe32398
-   */
-  position: absolute;
+  position: fixed;
   height: 100%;
   width: 100%;
   pointer-events: none;
@@ -42,6 +38,18 @@
   overflow: hidden;
   top: 0;
 }
+
+/* Taret iOS Safari */
+@supports (-webkit-overflow-scrolling: touch) {
+  /* This needs to position `absolute` instead of `fixed` (which is what it should be)
+   * due to this utterly absurd webkit iOS bug:
+   * https://gist.github.com/avesus/957889b4941239490c6c441adbe32398
+   */
+   :global(.modalRootContainer) {
+     position: absolute;
+   }
+}
+
 
 :global(#modalRoot) {
   /* This needs to position `relative` so that multiple modals can overlay each other */

--- a/src/Modal/Modal.module.css
+++ b/src/Modal/Modal.module.css
@@ -39,7 +39,7 @@
   top: 0;
 }
 
-/* Taret iOS Safari */
+/* Target iOS Safari */
 @supports (-webkit-overflow-scrolling: touch) {
   /* This needs to position `absolute` instead of `fixed` (which is what it should be)
    * due to this utterly absurd webkit iOS bug:


### PR DESCRIPTION
This fixes a bug in the protocol dashboard, which scrolls on the body vs. inside some paginating view (in the dapp).
The bug manifests because the modal is mounted absolutely relative to the body div which scrolls by. Maybe not the optimal solution, but the iOS safari fix needs to only be applied to iOS safari, at least.