### PR TITLE
Fix modal cleaup bg overflow

### DIFF
--- a/src/Modal/hooks.ts
+++ b/src/Modal/hooks.ts
@@ -40,6 +40,7 @@ export const useModalScrollCount = () => {
        * This guarantees that the getCount call will return
        * an updated number. Else, getCount() may non-deterministically
        * return 0 or 1 on cleanup of a final modal.
+       * NOTE: This should only be triggered on un-mount when not closed
        */
       setImmediate(() => {
         if (isOverflowHidden && getCount() === 0) {

--- a/src/Modal/hooks.ts
+++ b/src/Modal/hooks.ts
@@ -31,6 +31,22 @@ export const useModalScrollCount = () => {
       setIsOverflowHidden(false)
       removeOverflowHidden()
     }
+    return () => {
+      /**
+       * On cleanup of the `useScrollLock` hook, if the modal is open,
+       * the count is decremented. Because the cleanup of this method
+       * depends on the cleanup of `useScrollLock`, setImmediate is
+       * used to push this check to the end of the event loop.
+       * This guarantees that the getCount call will return
+       * an updated number. Else, getCount() may non-deterministically
+       * return 0 or 1 on cleanup of a final modal.
+       */
+      setImmediate(() => {
+        if (isOverflowHidden && getCount() === 0) {
+          removeOverflowHidden()
+        }
+      })
+    }
   }, [getCount, isOverflowHidden, toggle])
 
   const incrementScrollCount = useCallback(() => {


### PR DESCRIPTION
### Problem
If the modal is open and the component is unmounted, the style `overflow:hidden` is still left on the html body component which prevents scrolling.

This occurs because the `useModalScrollCount` hook will only remove that style if the count goes to zero. 
On unmount of the `useScrollLock` hook, the count is decremented if the modal is open, setting the count to zero, but this never triggers the useEffect in `useModalScrollCount` to remove the style. 

### Solution
Add a cleanup method to `useModalScrollCount` to check the count after the `useScrollLock` hook's cleanup method is called by using setImmediate. 

Closes AUD-132