### PR TITLE
Change overflow to auto instead of scroll to hide if not needed

### DIFF
--- a/src/Modal/Modal.module.css
+++ b/src/Modal/Modal.module.css
@@ -65,7 +65,7 @@
 .body {
   border-radius: 6px;
   background-color: var(--white);
-  overflow-y: scroll;
+  overflow-y: auto;
   overflow-x: hidden;
   max-height: 85vh;
   -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
If overflow set to scroll, scrollbar will be displayed even if not needed - w/ the auto value, it is hidden if not needed. 