### PR TITLE
Add back missing scrubber handle height

### DIFF
--- a/src/components/Scrubber/Slider.module.css
+++ b/src/components/Scrubber/Slider.module.css
@@ -86,6 +86,7 @@
 
 .handle {
   margin-left: var(--negative-unit);
+  height: var(--unit-2);
   width: var(--unit-2);
   border-radius: 50%;
   background: var(--white);


### PR DESCRIPTION
Bug in scrubber was introduced (accidentally) in https://github.com/AudiusProject/stems/pull/41/files#diff-b14ee666ce12fda09cbb72f8bbc43ffae96e9ab8dc8b661259f69a58a981d600L93

Tested:
- Linked client web + mobile
- Linked embed player tiny, compact, and card sizes

Only spot we do not show a handle is tiny embed and that still properly hides the handle

![Screen Shot 2021-07-19 at 5 12 53 PM](https://user-images.githubusercontent.com/2731362/126243137-7f5006a2-0942-423d-bd5a-5b147d160eb0.png)
