### PR TITLE
Add forward refs to Popup and PopupMenu

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -28,7 +28,7 @@ const TYPE_STYLE_MAP = {
  * include and position icons.
  */
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  (
+  function Button(
     {
       text,
       type,
@@ -48,9 +48,9 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       onMouseLeave,
       onMouseUp,
       onMouseDown
-    }: ButtonProps,
+    },
     ref
-  ) => {
+  ) {
     const { textIsHidden } = useCollapsibleText(widthToHideText)
 
     const renderLeftIcon = () =>

--- a/src/components/Popup/Popup.tsx
+++ b/src/components/Popup/Popup.tsx
@@ -75,203 +75,195 @@ const getComputedPosition = (
  * from modals, which do take over the whole UI and are usually
  * center-screened.
  */
-export const Popup = forwardRef<HTMLElement, PopupProps>(
-  (
-    {
-      anchorRef,
-      animationDuration,
-      checkIfClickInside,
-      children,
-      className,
-      isVisible,
-      onAfterClose,
-      onClose,
-      position = Position.BOTTOM_CENTER,
-      showHeader,
-      title,
-      wrapperClassName,
-      zIndex
+export const Popup = forwardRef<HTMLElement, PopupProps>(function Popup(
+  {
+    anchorRef,
+    animationDuration,
+    checkIfClickInside,
+    children,
+    className,
+    isVisible,
+    onAfterClose,
+    onClose,
+    position = Position.BOTTOM_CENTER,
+    showHeader,
+    title,
+    wrapperClassName,
+    zIndex
+  },
+  ref
+) {
+  const handleClose = useCallback(() => {
+    onClose()
+    setTimeout(() => {
+      onAfterClose()
+    }, animationDuration)
+  }, [onClose, onAfterClose, animationDuration])
+
+  const popupRef: React.MutableRefObject<HTMLDivElement> = useClickOutside(
+    handleClose,
+    checkIfClickInside,
+    typeof ref === 'function' ? undefined : ref
+  )
+
+  const wrapperRef = useRef<HTMLDivElement>()
+  const originalTopPosition = useRef<number>(0)
+  const [computedPosition, setComputedPosition] = useState(position)
+
+  const getRects = () =>
+    [anchorRef, wrapperRef].map(r => r.current.getBoundingClientRect())
+
+  useEffect(() => {
+    if (isVisible) {
+      const [anchorRect, wrapperRect] = getRects()
+      const computed = getComputedPosition(position, anchorRect, wrapperRect)
+      setComputedPosition(computed)
+    }
+  }, [isVisible, setComputedPosition, position, anchorRef, wrapperRef])
+
+  // On visible, set the position
+  useEffect(() => {
+    if (isVisible) {
+      const [anchorRect, wrapperRect] = getRects()
+
+      const positionMap = {
+        [Position.TOP_LEFT]: [
+          anchorRect.y - wrapperRect.height,
+          anchorRect.x - wrapperRect.width
+        ],
+        [Position.TOP_CENTER]: [
+          anchorRect.y - wrapperRect.height,
+          anchorRect.x - wrapperRect.width / 2 + anchorRect.width / 2
+        ],
+        [Position.TOP_RIGHT]: [
+          anchorRect.y - wrapperRect.height,
+          anchorRect.x + anchorRect.width
+        ],
+        [Position.BOTTOM_LEFT]: [
+          anchorRect.y + anchorRect.height,
+          anchorRect.x - wrapperRect.width
+        ],
+        [Position.BOTTOM_CENTER]: [
+          anchorRect.y + anchorRect.height,
+          anchorRect.x - wrapperRect.width / 2 + anchorRect.width / 2
+        ],
+        [Position.BOTTOM_RIGHT]: [
+          anchorRect.y + anchorRect.height,
+          anchorRect.x + anchorRect.width
+        ]
+      }
+
+      const [top, left] =
+        positionMap[computedPosition] ?? positionMap[Position.BOTTOM_CENTER]
+
+      wrapperRef.current.style.top = `${top}px`
+      wrapperRef.current.style.left = `${left}px`
+
+      originalTopPosition.current = top
+    }
+  }, [isVisible, wrapperRef, anchorRef, computedPosition, originalTopPosition])
+
+  // Callback invoked on each scroll. Uses original top position to scroll with content.
+  // Takes scrollParent to get the current scroll position as well as the intitial scroll position
+  // when the popup became visible.
+  const watchScroll = useCallback(
+    (scrollParent, initialScrollPosition) => {
+      const scrollTop = scrollParent.scrollTop
+      wrapperRef.current.style.top = `${
+        originalTopPosition.current - scrollTop + initialScrollPosition
+      }px`
     },
-    ref
-  ) => {
-    const handleClose = useCallback(() => {
-      onClose()
-      setTimeout(() => {
-        onAfterClose()
-      }, animationDuration)
-    }, [onClose, onAfterClose, animationDuration])
+    [wrapperRef, originalTopPosition]
+  )
 
-    const popupRef: React.MutableRefObject<HTMLDivElement> = useClickOutside(
-      handleClose,
-      checkIfClickInside,
-      typeof ref === 'function' ? undefined : ref
-    )
-
-    const wrapperRef = useRef<HTMLDivElement>()
-    const originalTopPosition = useRef<number>(0)
-    const [computedPosition, setComputedPosition] = useState(position)
-
-    const getRects = () =>
-      [anchorRef, wrapperRef].map(r => r.current.getBoundingClientRect())
-
-    useEffect(() => {
-      if (isVisible) {
-        const [anchorRect, wrapperRect] = getRects()
-        const computed = getComputedPosition(position, anchorRect, wrapperRect)
-        setComputedPosition(computed)
+  // Set up scroll listeners
+  useEffect(() => {
+    if (isVisible && anchorRef.current) {
+      const scrollParent = getScrollParent(anchorRef.current)
+      const initialScrollPosition = scrollParent.scrollTop
+      const listener = () => watchScroll(scrollParent, initialScrollPosition)
+      scrollParent.addEventListener('scroll', listener)
+      return () => {
+        scrollParent.removeEventListener('scroll', listener)
       }
-    }, [isVisible, setComputedPosition, position, anchorRef, wrapperRef])
+    }
 
-    // On visible, set the position
-    useEffect(() => {
-      if (isVisible) {
-        const [anchorRect, wrapperRect] = getRects()
+    return () => {}
+  }, [isVisible, watchScroll, anchorRef])
 
-        const positionMap = {
-          [Position.TOP_LEFT]: [
-            anchorRect.y - wrapperRect.height,
-            anchorRect.x - wrapperRect.width
-          ],
-          [Position.TOP_CENTER]: [
-            anchorRect.y - wrapperRect.height,
-            anchorRect.x - wrapperRect.width / 2 + anchorRect.width / 2
-          ],
-          [Position.TOP_RIGHT]: [
-            anchorRect.y - wrapperRect.height,
-            anchorRect.x + anchorRect.width
-          ],
-          [Position.BOTTOM_LEFT]: [
-            anchorRect.y + anchorRect.height,
-            anchorRect.x - wrapperRect.width
-          ],
-          [Position.BOTTOM_CENTER]: [
-            anchorRect.y + anchorRect.height,
-            anchorRect.x - wrapperRect.width / 2 + anchorRect.width / 2
-          ],
-          [Position.BOTTOM_RIGHT]: [
-            anchorRect.y + anchorRect.height,
-            anchorRect.x + anchorRect.width
-          ]
-        }
-
-        const [top, left] =
-          positionMap[computedPosition] ?? positionMap[Position.BOTTOM_CENTER]
-
-        wrapperRef.current.style.top = `${top}px`
-        wrapperRef.current.style.left = `${left}px`
-
-        originalTopPosition.current = top
-      }
-    }, [
-      isVisible,
-      wrapperRef,
-      anchorRef,
-      computedPosition,
-      originalTopPosition
-    ])
-
-    // Callback invoked on each scroll. Uses original top position to scroll with content.
-    // Takes scrollParent to get the current scroll position as well as the intitial scroll position
-    // when the popup became visible.
-    const watchScroll = useCallback(
-      (scrollParent, initialScrollPosition) => {
-        const scrollTop = scrollParent.scrollTop
-        wrapperRef.current.style.top = `${
-          originalTopPosition.current - scrollTop + initialScrollPosition
-        }px`
-      },
-      [wrapperRef, originalTopPosition]
-    )
-
-    // Set up scroll listeners
-    useEffect(() => {
-      if (isVisible && anchorRef.current) {
-        const scrollParent = getScrollParent(anchorRef.current)
-        const initialScrollPosition = scrollParent.scrollTop
-        const listener = () => watchScroll(scrollParent, initialScrollPosition)
-        scrollParent.addEventListener('scroll', listener)
-        return () => {
-          scrollParent.removeEventListener('scroll', listener)
+  // Set up key listeners
+  useEffect(() => {
+    if (isVisible) {
+      const escapeListener = (e: KeyboardEvent) => {
+        if (e.code === 'Escape') {
+          handleClose()
         }
       }
 
-      return () => {}
-    }, [isVisible, watchScroll, anchorRef])
+      window.addEventListener('keydown', escapeListener)
 
-    // Set up key listeners
-    useEffect(() => {
-      if (isVisible) {
-        const escapeListener = (e: KeyboardEvent) => {
-          if (e.code === 'Escape') {
-            handleClose()
-          }
-        }
+      return () => window.removeEventListener('keydown', escapeListener)
+    }
+    return () => {}
+  }, [isVisible])
 
-        window.addEventListener('keydown', escapeListener)
+  const transitions = useTransition(isVisible, null, {
+    from: {
+      transform: `scale(0)`,
+      opacity: 0
+    },
+    enter: {
+      transform: `scale(1)`,
+      opacity: 1
+    },
+    leave: {
+      transform: `scale(0)`,
+      opacity: 0
+    },
+    config: { duration: 180 },
+    unique: true
+  })
 
-        return () => window.removeEventListener('keydown', escapeListener)
-      }
-      return () => {}
-    }, [isVisible])
+  const wrapperStyle = zIndex ? { zIndex } : {}
 
-    const transitions = useTransition(isVisible, null, {
-      from: {
-        transform: `scale(0)`,
-        opacity: 0
-      },
-      enter: {
-        transform: `scale(1)`,
-        opacity: 1
-      },
-      leave: {
-        transform: `scale(0)`,
-        opacity: 0
-      },
-      config: { duration: 180 },
-      unique: true
-    })
-
-    const wrapperStyle = zIndex ? { zIndex } : {}
-
-    return (
-      <>
-        {/* Portal the popup out of the dom structure so that it has a separate stacking context */}
-        {ReactDOM.createPortal(
-          <div
-            ref={wrapperRef}
-            className={cn(styles.wrapper, wrapperClassName)}
-            style={wrapperStyle}
-          >
-            {transitions.map(({ item, key, props }) =>
-              item ? (
-                <animated.div
-                  className={cn(styles.popup, className)}
-                  ref={popupRef}
-                  key={key}
-                  style={{
-                    ...props,
-                    transformOrigin: getTransformOrigin(computedPosition)
-                  }}
-                >
-                  {showHeader && (
-                    <div className={styles.header}>
-                      <IconRemove
-                        className={styles.iconRemove}
-                        onClick={handleClose}
-                      />
-                      <div className={styles.title}>{title}</div>
-                    </div>
-                  )}
-                  {children}
-                </animated.div>
-              ) : null
-            )}
-          </div>,
-          document.body
-        )}
-      </>
-    )
-  }
-)
+  return (
+    <>
+      {/* Portal the popup out of the dom structure so that it has a separate stacking context */}
+      {ReactDOM.createPortal(
+        <div
+          ref={wrapperRef}
+          className={cn(styles.wrapper, wrapperClassName)}
+          style={wrapperStyle}
+        >
+          {transitions.map(({ item, key, props }) =>
+            item ? (
+              <animated.div
+                className={cn(styles.popup, className)}
+                ref={popupRef}
+                key={key}
+                style={{
+                  ...props,
+                  transformOrigin: getTransformOrigin(computedPosition)
+                }}
+              >
+                {showHeader && (
+                  <div className={styles.header}>
+                    <IconRemove
+                      className={styles.iconRemove}
+                      onClick={handleClose}
+                    />
+                    <div className={styles.title}>{title}</div>
+                  </div>
+                )}
+                {children}
+              </animated.div>
+            ) : null
+          )}
+        </div>,
+        document.body
+      )}
+    </>
+  )
+})
 
 Popup.defaultProps = popupDefaultProps

--- a/src/components/Popup/Popup.tsx
+++ b/src/components/Popup/Popup.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useRef,
+  useState
+} from 'react'
 
 import cn from 'classnames'
 import ReactDOM from 'react-dom'
@@ -69,191 +75,203 @@ const getComputedPosition = (
  * from modals, which do take over the whole UI and are usually
  * center-screened.
  */
-export const Popup = ({
-  anchorRef,
-  animationDuration,
-  checkIfClickInside,
-  children,
-  className,
-  isVisible,
-  onAfterClose,
-  onClose,
-  position = Position.BOTTOM_CENTER,
-  showHeader,
-  title,
-  wrapperClassName,
-  zIndex
-}: PopupProps) => {
-  const handleClose = useCallback(() => {
-    onClose()
-    setTimeout(() => {
-      onAfterClose()
-    }, animationDuration)
-  }, [onClose, onAfterClose, animationDuration])
-
-  const popupRef: React.MutableRefObject<HTMLDivElement> = useClickOutside(
-    handleClose,
-    checkIfClickInside
-  )
-
-  const wrapperRef = useRef<HTMLDivElement>()
-  const originalTopPosition = useRef<number>(0)
-  const [computedPosition, setComputedPosition] = useState(position)
-
-  const getRects = () =>
-    [anchorRef, wrapperRef].map(r => r.current.getBoundingClientRect())
-
-  useEffect(() => {
-    if (isVisible) {
-      const [anchorRect, wrapperRect] = getRects()
-      const computed = getComputedPosition(position, anchorRect, wrapperRect)
-      setComputedPosition(computed)
-    }
-  }, [isVisible, setComputedPosition, position, anchorRef, wrapperRef])
-
-  // On visible, set the position
-  useEffect(() => {
-    if (isVisible) {
-      const [anchorRect, wrapperRect] = getRects()
-
-      const positionMap = {
-        [Position.TOP_LEFT]: [
-          anchorRect.y - wrapperRect.height,
-          anchorRect.x - wrapperRect.width
-        ],
-        [Position.TOP_CENTER]: [
-          anchorRect.y - wrapperRect.height,
-          anchorRect.x - wrapperRect.width / 2 + anchorRect.width / 2
-        ],
-        [Position.TOP_RIGHT]: [
-          anchorRect.y - wrapperRect.height,
-          anchorRect.x + anchorRect.width
-        ],
-        [Position.BOTTOM_LEFT]: [
-          anchorRect.y + anchorRect.height,
-          anchorRect.x - wrapperRect.width
-        ],
-        [Position.BOTTOM_CENTER]: [
-          anchorRect.y + anchorRect.height,
-          anchorRect.x - wrapperRect.width / 2 + anchorRect.width / 2
-        ],
-        [Position.BOTTOM_RIGHT]: [
-          anchorRect.y + anchorRect.height,
-          anchorRect.x + anchorRect.width
-        ]
-      }
-
-      const [top, left] =
-        positionMap[computedPosition] ?? positionMap[Position.BOTTOM_CENTER]
-
-      wrapperRef.current.style.top = `${top}px`
-      wrapperRef.current.style.left = `${left}px`
-
-      originalTopPosition.current = top
-    }
-  }, [isVisible, wrapperRef, anchorRef, computedPosition, originalTopPosition])
-
-  // Callback invoked on each scroll. Uses original top position to scroll with content.
-  // Takes scrollParent to get the current scroll position as well as the intitial scroll position
-  // when the popup became visible.
-  const watchScroll = useCallback(
-    (scrollParent, initialScrollPosition) => {
-      const scrollTop = scrollParent.scrollTop
-      wrapperRef.current.style.top = `${
-        originalTopPosition.current - scrollTop + initialScrollPosition
-      }px`
+export const Popup = forwardRef<HTMLElement, PopupProps>(
+  (
+    {
+      anchorRef,
+      animationDuration,
+      checkIfClickInside,
+      children,
+      className,
+      isVisible,
+      onAfterClose,
+      onClose,
+      position = Position.BOTTOM_CENTER,
+      showHeader,
+      title,
+      wrapperClassName,
+      zIndex
     },
-    [wrapperRef, originalTopPosition]
-  )
+    ref
+  ) => {
+    const handleClose = useCallback(() => {
+      onClose()
+      setTimeout(() => {
+        onAfterClose()
+      }, animationDuration)
+    }, [onClose, onAfterClose, animationDuration])
 
-  // Set up scroll listeners
-  useEffect(() => {
-    if (isVisible && anchorRef.current) {
-      const scrollParent = getScrollParent(anchorRef.current)
-      const initialScrollPosition = scrollParent.scrollTop
-      const listener = () => watchScroll(scrollParent, initialScrollPosition)
-      scrollParent.addEventListener('scroll', listener)
-      return () => {
-        scrollParent.removeEventListener('scroll', listener)
+    const popupRef: React.MutableRefObject<HTMLDivElement> = useClickOutside(
+      handleClose,
+      checkIfClickInside,
+      typeof ref === 'function' ? undefined : ref
+    )
+
+    const wrapperRef = useRef<HTMLDivElement>()
+    const originalTopPosition = useRef<number>(0)
+    const [computedPosition, setComputedPosition] = useState(position)
+
+    const getRects = () =>
+      [anchorRef, wrapperRef].map(r => r.current.getBoundingClientRect())
+
+    useEffect(() => {
+      if (isVisible) {
+        const [anchorRect, wrapperRect] = getRects()
+        const computed = getComputedPosition(position, anchorRect, wrapperRect)
+        setComputedPosition(computed)
       }
-    }
+    }, [isVisible, setComputedPosition, position, anchorRef, wrapperRef])
 
-    return () => {}
-  }, [isVisible, watchScroll, anchorRef])
+    // On visible, set the position
+    useEffect(() => {
+      if (isVisible) {
+        const [anchorRect, wrapperRect] = getRects()
 
-  // Set up key listeners
-  useEffect(() => {
-    if (isVisible) {
-      const escapeListener = (e: KeyboardEvent) => {
-        if (e.code === 'Escape') {
-          handleClose()
+        const positionMap = {
+          [Position.TOP_LEFT]: [
+            anchorRect.y - wrapperRect.height,
+            anchorRect.x - wrapperRect.width
+          ],
+          [Position.TOP_CENTER]: [
+            anchorRect.y - wrapperRect.height,
+            anchorRect.x - wrapperRect.width / 2 + anchorRect.width / 2
+          ],
+          [Position.TOP_RIGHT]: [
+            anchorRect.y - wrapperRect.height,
+            anchorRect.x + anchorRect.width
+          ],
+          [Position.BOTTOM_LEFT]: [
+            anchorRect.y + anchorRect.height,
+            anchorRect.x - wrapperRect.width
+          ],
+          [Position.BOTTOM_CENTER]: [
+            anchorRect.y + anchorRect.height,
+            anchorRect.x - wrapperRect.width / 2 + anchorRect.width / 2
+          ],
+          [Position.BOTTOM_RIGHT]: [
+            anchorRect.y + anchorRect.height,
+            anchorRect.x + anchorRect.width
+          ]
+        }
+
+        const [top, left] =
+          positionMap[computedPosition] ?? positionMap[Position.BOTTOM_CENTER]
+
+        wrapperRef.current.style.top = `${top}px`
+        wrapperRef.current.style.left = `${left}px`
+
+        originalTopPosition.current = top
+      }
+    }, [
+      isVisible,
+      wrapperRef,
+      anchorRef,
+      computedPosition,
+      originalTopPosition
+    ])
+
+    // Callback invoked on each scroll. Uses original top position to scroll with content.
+    // Takes scrollParent to get the current scroll position as well as the intitial scroll position
+    // when the popup became visible.
+    const watchScroll = useCallback(
+      (scrollParent, initialScrollPosition) => {
+        const scrollTop = scrollParent.scrollTop
+        wrapperRef.current.style.top = `${
+          originalTopPosition.current - scrollTop + initialScrollPosition
+        }px`
+      },
+      [wrapperRef, originalTopPosition]
+    )
+
+    // Set up scroll listeners
+    useEffect(() => {
+      if (isVisible && anchorRef.current) {
+        const scrollParent = getScrollParent(anchorRef.current)
+        const initialScrollPosition = scrollParent.scrollTop
+        const listener = () => watchScroll(scrollParent, initialScrollPosition)
+        scrollParent.addEventListener('scroll', listener)
+        return () => {
+          scrollParent.removeEventListener('scroll', listener)
         }
       }
 
-      window.addEventListener('keydown', escapeListener)
+      return () => {}
+    }, [isVisible, watchScroll, anchorRef])
 
-      return () => window.removeEventListener('keydown', escapeListener)
-    }
-    return () => {}
-  }, [isVisible])
+    // Set up key listeners
+    useEffect(() => {
+      if (isVisible) {
+        const escapeListener = (e: KeyboardEvent) => {
+          if (e.code === 'Escape') {
+            handleClose()
+          }
+        }
 
-  const transitions = useTransition(isVisible, null, {
-    from: {
-      transform: `scale(0)`,
-      opacity: 0
-    },
-    enter: {
-      transform: `scale(1)`,
-      opacity: 1
-    },
-    leave: {
-      transform: `scale(0)`,
-      opacity: 0
-    },
-    config: { duration: 180 },
-    unique: true
-  })
+        window.addEventListener('keydown', escapeListener)
 
-  const wrapperStyle = zIndex ? { zIndex } : {}
+        return () => window.removeEventListener('keydown', escapeListener)
+      }
+      return () => {}
+    }, [isVisible])
 
-  return (
-    <>
-      {/* Portal the popup out of the dom structure so that it has a separate stacking context */}
-      {ReactDOM.createPortal(
-        <div
-          ref={wrapperRef}
-          className={cn(styles.wrapper, wrapperClassName)}
-          style={wrapperStyle}
-        >
-          {transitions.map(({ item, key, props }) =>
-            item ? (
-              <animated.div
-                className={cn(styles.popup, className)}
-                ref={popupRef}
-                key={key}
-                style={{
-                  ...props,
-                  transformOrigin: getTransformOrigin(computedPosition)
-                }}
-              >
-                {showHeader && (
-                  <div className={styles.header}>
-                    <IconRemove
-                      className={styles.iconRemove}
-                      onClick={handleClose}
-                    />
-                    <div className={styles.title}>{title}</div>
-                  </div>
-                )}
-                {children}
-              </animated.div>
-            ) : null
-          )}
-        </div>,
-        document.body
-      )}
-    </>
-  )
-}
+    const transitions = useTransition(isVisible, null, {
+      from: {
+        transform: `scale(0)`,
+        opacity: 0
+      },
+      enter: {
+        transform: `scale(1)`,
+        opacity: 1
+      },
+      leave: {
+        transform: `scale(0)`,
+        opacity: 0
+      },
+      config: { duration: 180 },
+      unique: true
+    })
+
+    const wrapperStyle = zIndex ? { zIndex } : {}
+
+    return (
+      <>
+        {/* Portal the popup out of the dom structure so that it has a separate stacking context */}
+        {ReactDOM.createPortal(
+          <div
+            ref={wrapperRef}
+            className={cn(styles.wrapper, wrapperClassName)}
+            style={wrapperStyle}
+          >
+            {transitions.map(({ item, key, props }) =>
+              item ? (
+                <animated.div
+                  className={cn(styles.popup, className)}
+                  ref={popupRef}
+                  key={key}
+                  style={{
+                    ...props,
+                    transformOrigin: getTransformOrigin(computedPosition)
+                  }}
+                >
+                  {showHeader && (
+                    <div className={styles.header}>
+                      <IconRemove
+                        className={styles.iconRemove}
+                        onClick={handleClose}
+                      />
+                      <div className={styles.title}>{title}</div>
+                    </div>
+                  )}
+                  {children}
+                </animated.div>
+              ) : null
+            )}
+          </div>,
+          document.body
+        )}
+      </>
+    )
+  }
+)
 
 Popup.defaultProps = popupDefaultProps

--- a/src/components/PopupMenu/PopupMenu.tsx
+++ b/src/components/PopupMenu/PopupMenu.tsx
@@ -11,7 +11,10 @@ import { PopupMenuItem, PopupMenuProps } from './types'
  * A menu that shows on top of the UI. Ideal for overflow menus, dropdowns, etc
  */
 export const PopupMenu = forwardRef<HTMLElement, PopupMenuProps>(
-  ({ items, onClose, position, renderTrigger, title, zIndex }, ref) => {
+  function PopupMenu(
+    { items, onClose, position, renderTrigger, title, zIndex },
+    ref
+  ) {
     const clickInsideRef = useRef<any>()
     const anchorRef = useRef<HTMLElement>()
 

--- a/src/components/PopupMenu/PopupMenu.tsx
+++ b/src/components/PopupMenu/PopupMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from 'react'
+import React, { forwardRef, useCallback, useRef, useState } from 'react'
 
 import cn from 'classnames'
 
@@ -10,73 +10,69 @@ import { PopupMenuItem, PopupMenuProps } from './types'
 /**
  * A menu that shows on top of the UI. Ideal for overflow menus, dropdowns, etc
  */
-export const PopupMenu = ({
-  items,
-  onClose,
-  position,
-  renderTrigger,
-  title,
-  zIndex
-}: PopupMenuProps) => {
-  const clickInsideRef = useRef<any>()
-  const anchorRef = useRef<HTMLElement>()
+export const PopupMenu = forwardRef<HTMLElement, PopupMenuProps>(
+  ({ items, onClose, position, renderTrigger, title, zIndex }, ref) => {
+    const clickInsideRef = useRef<any>()
+    const anchorRef = useRef<HTMLElement>()
 
-  const [isPopupVisible, setIsPopupVisible] = useState<boolean>(false)
+    const [isPopupVisible, setIsPopupVisible] = useState<boolean>(false)
 
-  const triggerPopup = useCallback(() => setIsPopupVisible(!isPopupVisible), [
-    isPopupVisible,
-    setIsPopupVisible
-  ])
+    const triggerPopup = useCallback(() => setIsPopupVisible(!isPopupVisible), [
+      isPopupVisible,
+      setIsPopupVisible
+    ])
 
-  const handleMenuItemClick = useCallback(
-    (item: PopupMenuItem) => (e: React.MouseEvent) => {
-      e.stopPropagation()
-      item.onClick()
-      handlePopupClose()
-    },
-    [setIsPopupVisible]
-  )
+    const handleMenuItemClick = useCallback(
+      (item: PopupMenuItem) => (e: React.MouseEvent) => {
+        e.stopPropagation()
+        item.onClick()
+        handlePopupClose()
+      },
+      [setIsPopupVisible]
+    )
 
-  const handlePopupClose = useCallback(() => {
-    setIsPopupVisible(false)
-    onClose?.()
-  }, [setIsPopupVisible])
+    const handlePopupClose = useCallback(() => {
+      setIsPopupVisible(false)
+      onClose?.()
+    }, [setIsPopupVisible])
 
-  return (
-    <div ref={clickInsideRef}>
-      {renderTrigger(anchorRef, triggerPopup)}
-      <Popup
-        anchorRef={anchorRef}
-        checkIfClickInside={(target: EventTarget) => {
-          if (target instanceof Element && clickInsideRef) {
-            return clickInsideRef.current.contains(target)
-          }
-          return false
-        }}
-        isVisible={isPopupVisible}
-        showHeader={Boolean(title)}
-        onClose={handlePopupClose}
-        position={position}
-        title={title || ''}
-        zIndex={zIndex}
-      >
-        <div className={styles.menu}>
-          {items.map((item, i) => (
-            <div
-              key={typeof item.text === 'string' ? `${item.text}_${i}` : i}
-              className={cn(styles.item, item.className)}
-              onClick={handleMenuItemClick(item)}
-            >
-              {item.icon && (
-                <div className={cn(styles.icon, item.iconClassName)}>
-                  {item.icon}
-                </div>
-              )}
-              {item.text}
-            </div>
-          ))}
-        </div>
-      </Popup>
-    </div>
-  )
-}
+    return (
+      <div ref={clickInsideRef}>
+        {renderTrigger(anchorRef, triggerPopup)}
+        <Popup
+          anchorRef={anchorRef}
+          checkIfClickInside={(target: EventTarget) => {
+            if (target instanceof Element && clickInsideRef) {
+              return clickInsideRef.current.contains(target)
+            }
+            return false
+          }}
+          isVisible={isPopupVisible}
+          showHeader={Boolean(title)}
+          onClose={handlePopupClose}
+          position={position}
+          ref={ref}
+          title={title || ''}
+          zIndex={zIndex}
+        >
+          <div className={styles.menu}>
+            {items.map((item, i) => (
+              <div
+                key={typeof item.text === 'string' ? `${item.text}_${i}` : i}
+                className={cn(styles.item, item.className)}
+                onClick={handleMenuItemClick(item)}
+              >
+                {item.icon && (
+                  <div className={cn(styles.icon, item.iconClassName)}>
+                    {item.icon}
+                  </div>
+                )}
+                {item.text}
+              </div>
+            ))}
+          </div>
+        </Popup>
+      </div>
+    )
+  }
+)

--- a/src/components/PopupMenu/types.tsx
+++ b/src/components/PopupMenu/types.tsx
@@ -1,5 +1,7 @@
 import { PopupProps } from '../Popup'
 
+type ApplicablePopupProps = Pick<PopupProps, 'position' | 'title' | 'zIndex'>
+
 export type PopupMenuProps = {
   /**
    * The items to display in the menu
@@ -18,7 +20,7 @@ export type PopupMenuProps = {
     anchorRef: React.MutableRefObject<any>,
     triggerPopup: () => void
   ) => React.ReactNode | Element
-} & Pick<PopupProps, 'position' | 'title' | 'zIndex'>
+} & ApplicablePopupProps
 
 export type PopupMenuItem = {
   /**

--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { MutableRefObject, useEffect, useRef } from 'react'
 
 /**
  * Custom hook that fires an onClick callback when the user clicks
@@ -8,14 +8,16 @@ import { useEffect, useRef } from 'react'
  * @param ignoreClick optional check to be run on the element that receives
  * the "click." If ignoreClick returns true, the click is not considered outside
  * even if it was outside the element referenced.
+ * @param defaultRef optional ref to use, if not provided a new ref will be created & returned
   
  * @returns a ref that should be used to mark the "inside" element
  */
 export const useClickOutside = (
   onClick: () => void,
-  ignoreClick: (target: EventTarget) => boolean = () => false
+  ignoreClick: (target: EventTarget) => boolean = () => false,
+  defaultRef?: MutableRefObject<any>
 ) => {
-  const ref = useRef(null)
+  const ref = useRef(defaultRef?.current ?? null)
 
   useEffect(() => {
     const handleClick = (e: MouseEvent) => {


### PR DESCRIPTION
This PR:

* Adds forward refs to `Popup` and `PopupMenu` (looks like a lot of changes in the diff but it's really just wrapping each component in `forwardRef()`

## Reasoning
Eventually I think all stems components should have forward refs to the underlying dom elements so that consumers of the library have full flexibility & control. A good example of a use case is needing to find the position of a `Button` to trigger a `Popup` in the correct location.

In this case, the refs on `Popup` and `PopupMenu` are useful to handle clicks that should be considered inside/outside nested `Popup`s