### PR TITLE
Fix disabled button, update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@
 
 ## Installation
 
+Install `@audius/stems` required peer dependencies:
+```bash
+npm install --save bn.js classnames@2.2.6 lodash@4.17.20 moment@2.24.0 prop-types react react-dom react-spring@8.0.27
+```
+
+Then install `@audius/stems`
 ```bash
 npm install --save @audius/stems
 ```

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -95,7 +95,8 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           className
         )}
         name={name}
-        onClick={isDisabled ? () => {} : onClick}
+        disabled={isDisabled}
+        onClick={onClick}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
         onMouseUp={onMouseUp}


### PR DESCRIPTION
- Passes `isDisabled` prop to `disabled` html attr. This will also prevent onClick from triggering, and is more accessible. This is also necessary for cypress to retry-click a disabled button that is transitioning to not-disabled
- Updates readme to improve install instructions