### PR TITLE
[AUD-1359] Fix button label and buttonType

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -77,6 +77,8 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 
     const getAriaLabel = () => {
       if (ariaLabelProp) return ariaLabelProp
+      // Use the text prop as the aria-label if the text becomes hidden
+      // and no aria-label was provided to keep the button accessible.
       else if (textIsHidden && typeof text === 'string') return text
       return undefined
     }

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -51,8 +51,8 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   ) {
     const { textIsHidden } = useCollapsibleText(widthToHideText)
     const disabled = disabledProp ?? isDisabled
-    const noText = !text || textIsHidden
-    const hasText = !!text && !textIsHidden
+    const isTextVisible = !!text && !textIsHidden
+    const noText = !isTextVisible
 
     const renderLeftIcon = () =>
       leftIcon && (
@@ -78,12 +78,12 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 
     const getAriaLabel = () => {
       if (ariaLabelProp) return ariaLabelProp
-      else if (hasText && typeof text === 'string') return text
+      else if (textIsHidden && typeof text === 'string') return text
       return undefined
     }
 
     const renderText = () =>
-      hasText && (
+      isTextVisible && (
         <span className={cn(styles.textLabel, textClassName)}>{text}</span>
       )
 
@@ -105,7 +105,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         type={buttonType}
         ref={ref}
         style={{
-          minWidth: minWidth && hasText ? `${minWidth}px` : 'unset'
+          minWidth: minWidth && isTextVisible ? `${minWidth}px` : 'unset'
         }}
         {...other}
       >

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -4,7 +4,7 @@ import cn from 'classnames'
 
 import styles from './Button.module.css'
 import { useCollapsibleText } from './hooks'
-import { ButtonProps, Type, Size, defaultButtonProps } from './types'
+import { ButtonProps, Type, Size } from './types'
 
 const SIZE_STYLE_MAP = {
   [Size.TINY]: styles.tiny,
@@ -31,33 +31,34 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   function Button(
     {
       text,
-      type,
-      size,
+      type = Type.PRIMARY,
+      buttonType,
+      size = Size.MEDIUM,
       leftIcon,
       rightIcon,
       isDisabled,
-      includeHoverAnimations,
+      disabled: disabledProp,
+      includeHoverAnimations = true,
       widthToHideText,
       minWidth,
       className,
       iconClassName,
       textClassName,
-      name,
-      onClick,
-      onMouseEnter,
-      onMouseLeave,
-      onMouseUp,
-      onMouseDown
+      'aria-label': ariaLabelProp,
+      ...other
     },
     ref
   ) {
     const { textIsHidden } = useCollapsibleText(widthToHideText)
+    const disabled = disabledProp ?? isDisabled
+    const noText = !text || textIsHidden
+    const hasText = !!text && !textIsHidden
 
     const renderLeftIcon = () =>
       leftIcon && (
         <span
           className={cn(iconClassName, styles.icon, styles.left, {
-            [styles.noText]: !text || textIsHidden
+            [styles.noText]: noText
           })}
         >
           {leftIcon}
@@ -68,44 +69,45 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       rightIcon && (
         <span
           className={cn(iconClassName, styles.icon, styles.right, {
-            [styles.noText]: !text || textIsHidden
+            [styles.noText]: noText
           })}
         >
           {rightIcon}
         </span>
       )
 
+    const getAriaLabel = () => {
+      if (ariaLabelProp) return ariaLabelProp
+      else if (hasText && typeof text === 'string') return text
+      return undefined
+    }
+
     const renderText = () =>
-      !!text &&
-      !textIsHidden && (
+      hasText && (
         <span className={cn(styles.textLabel, textClassName)}>{text}</span>
       )
 
     return (
       <button
+        aria-label={getAriaLabel()}
         className={cn(
           styles.button,
           SIZE_STYLE_MAP[size || Size.MEDIUM],
           TYPE_STYLE_MAP[type || Type.COMMON],
           {
             [styles.noIcon]: !leftIcon && !rightIcon,
-            [styles.disabled]: isDisabled,
+            [styles.disabled]: disabled,
             [styles.includeHoverAnimations]: includeHoverAnimations
           },
           className
         )}
-        name={name}
-        disabled={isDisabled}
-        onClick={onClick}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
-        onMouseUp={onMouseUp}
-        onMouseDown={onMouseDown}
+        disabled={disabled}
+        type={buttonType}
         ref={ref}
         style={{
-          minWidth:
-            minWidth && !!text && !textIsHidden ? `${minWidth}px` : 'unset'
+          minWidth: minWidth && hasText ? `${minWidth}px` : 'unset'
         }}
+        {...other}
       >
         {renderLeftIcon()}
         {renderText()}
@@ -114,5 +116,3 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     )
   }
 )
-
-Button.defaultProps = defaultButtonProps

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -52,13 +52,12 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     const { textIsHidden } = useCollapsibleText(widthToHideText)
     const disabled = disabledProp ?? isDisabled
     const isTextVisible = !!text && !textIsHidden
-    const noText = !isTextVisible
 
     const renderLeftIcon = () =>
       leftIcon && (
         <span
           className={cn(iconClassName, styles.icon, styles.left, {
-            [styles.noText]: noText
+            [styles.noText]: !isTextVisible
           })}
         >
           {leftIcon}
@@ -69,7 +68,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       rightIcon && (
         <span
           className={cn(iconClassName, styles.icon, styles.right, {
-            [styles.noText]: noText
+            [styles.noText]: !isTextVisible
           })}
         >
           {rightIcon}

--- a/src/components/Button/types.ts
+++ b/src/components/Button/types.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react'
+import { ComponentPropsWithoutRef, ReactNode } from 'react'
 
 export enum Type {
   PRIMARY = 'primary',
@@ -17,6 +17,11 @@ export enum Size {
   MEDIUM = 'medium'
 }
 
+type BaseButtonProps = Omit<
+  ComponentPropsWithoutRef<'button'>,
+  'type' | 'children'
+>
+
 export type ButtonProps = {
   /**
    * The text of the button
@@ -27,6 +32,11 @@ export type ButtonProps = {
    * The type of the button
    */
   type?: Type
+
+  /**
+   * The default behavior of the button.
+   */
+  buttonType?: 'submit' | 'button' | 'reset'
 
   /**
    * The button size
@@ -67,11 +77,6 @@ export type ButtonProps = {
   minWidth?: number
 
   /**
-   * Class name to apply to the outermost <button> element
-   */
-  className?: string
-
-  /**
    * Class name to apply to the icon
    */
   iconClassName?: string
@@ -80,30 +85,4 @@ export type ButtonProps = {
    * Class name to apply to the text label
    */
   textClassName?: string
-
-  /**
-   * HTML name attribute to apply to the button
-   */
-  name?: string
-
-  /**
-   * What happens when the button is clicked
-   */
-  onClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void
-
-  onMouseEnter?: () => void
-  onMouseLeave?: () => void
-  onMouseUp?: () => void
-  onMouseDown?: () => void
-}
-
-export const defaultButtonProps = {
-  type: Type.PRIMARY,
-  size: Size.MEDIUM,
-  includeHoverAnimations: true,
-  onClick: () => {},
-  onMouseEnter: () => {},
-  onMouseLeave: () => {},
-  onMouseUp: () => {},
-  onMouseDown: () => {}
-}
+} & BaseButtonProps


### PR DESCRIPTION
- Fixes issue where collapsed button has no label. It is now generated from `text` prop if it's a string, otherwise it uses the `aria-label` prop.
- Fixes issue where buttons in form cannot specify "type=submit", this is represented now by the `buttonType` prop
- Uses `HTMLButtonElement` types, and passes through all extra button props, simplifying type def and defaultProps