### PR TITLE
Add gradient colors to theme vars

### DIFF
--- a/src/assets/styles/colors.css
+++ b/src/assets/styles/colors.css
@@ -61,6 +61,8 @@ root {
 
   --primary-gradient: linear-gradient(135deg, #ee00ed 0%, #c514e0 100%);
   --secondary-gradient: linear-gradient(315deg, #6b0fb3 0%, #7e1bcc 100%);
+  --page-header-gradient-color-1: #5b23e1;
+  --page-header-gradient-color-2: #a22feb;
 
   --image-shadow: rgba(10, 10, 10, 0.35);
   --tile-shadow-1: rgba(133, 129, 153, 0.1);

--- a/src/components/ProgressBar/ProgressBar.module.css
+++ b/src/components/ProgressBar/ProgressBar.module.css
@@ -14,7 +14,11 @@
 }
 
 .sliderBar {
-  background: linear-gradient(315deg, #5B23E1 2.04%, #A22FEB 100%);
+  background: linear-gradient(
+    315deg,
+    var(--page-header-gradient-color-1) 2.04%,
+    var(--page-header-gradient-color-2) 100%
+  );
   bottom: 0;
   left: 0;
   position: absolute;
@@ -29,7 +33,8 @@
   padding: 0 4px;
 }
 
-.minLabel, .maxLabel {
+.minLabel,
+.maxLabel {
   color: var(--neutral-light-4);
   font-weight: var(--font-bold);
 }


### PR DESCRIPTION
Adds `--page-header-gradient-color-1` and `--page-header-gradient-color-2` to the `colors.css` so that we can use them in the progress bar.

Note: will revisit these names in the future.