### PR TITLE
[AUD-1394] Fix window resize modal bug

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -222,9 +222,13 @@ export const Modal = forwardRef<HTMLDivElement, ModalProps>(function Modal(
 
   const [height, setHeight] = useState(window.innerHeight)
   useEffect(() => {
-    const onResize = () => setHeight(window.innerHeight)
+    const onResize = () => {
+      setHeight(window.innerHeight)
+    }
     window.addEventListener('resize', onResize)
-    return window.removeEventListener('resize', onResize)
+    return () => {
+      window.removeEventListener('resize', onResize)
+    }
   }, [setHeight])
 
   const bodyOffset = getOffset(anchor, verticalAnchorOffset)


### PR DESCRIPTION
Tested:
- Linked stems locally against staging & ensured resizing the window left modal re-centered (with it open and with it closed)