### PR TITLE
Add polyfill for resize observer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2184,6 +2184,11 @@
         "@types/yargs": "^13.0.0"
       }
     },
+    "@juggle/resize-observer": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.3.1.tgz",
+      "integrity": "sha512-zMM9Ds+SawiUkakS7y94Ymqx+S0ORzpG3frZirN3l+UlXUmSUR7hF4wxCVqW+ei94JzV5kt0uXBcoOEAuiydrw=="
+    },
     "@mdx-js/loader": {
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/@mdx-js/loader/-/loader-1.6.22.tgz",

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "dist"
   ],
   "dependencies": {
+    "@juggle/resize-observer": "^3.3.1",
     "react-perfect-scrollbar": "1.5.8",
     "react-use-measure": "2.1.1"
   }

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "dist"
   ],
   "dependencies": {
-    "@juggle/resize-observer": "^3.3.1",
+    "@juggle/resize-observer": "3.3.1",
     "react-perfect-scrollbar": "1.5.8",
     "react-use-measure": "2.1.1"
   }

--- a/src/components/Scrollbar/Scrollbar.tsx
+++ b/src/components/Scrollbar/Scrollbar.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { ResizeObserver } from '@juggle/resize-observer'
 import cn from 'classnames'
 import PerfectScrollbar from 'react-perfect-scrollbar'
 import useMeasure from 'react-use-measure'
@@ -18,7 +19,7 @@ export const Scrollbar = ({
   className,
   ...props
 }: ScrollbarProps) => {
-  const [ref] = useMeasure()
+  const [ref] = useMeasure({ polyfill: ResizeObserver })
   return (
     <PerfectScrollbar {...props} className={cn(styles.scrollbar, className)}>
       <div ref={ref}>{children}</div>


### PR DESCRIPTION
 CI on [this branch](https://github.com/AudiusProject/audius-client/pull/1090) failing with:
```This browser does not support ResizeObserver out of the box. See: https://github.com/react-spring/react-use-measure/#resize-observer-polyfills

      34 |       HTMLDivElement | undefined
      35 |     >
    > 36 |     ReactDOM.render(
         |              ^
      37 |       <Provider store={store}>
      38 |         <ConnectedRouter history={history}>
      39 |           <App
```
Basically any use of Scrollbar will cause the app to crash on a browser that doesn't support ResizeObserver (pretty much just IE and then the CI "browser").
This polyfill should fix it.
