### PR TITLE
Use click instead of mousedown for listener

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -209,8 +209,8 @@ export const Modal = forwardRef<HTMLDivElement, ModalProps>(function Modal(
     (e: EventTarget) => {
       // Only close if we're open.
       // Closing when we're not open can cause a race condition when opened
-      // via a click since this handler exists prior to visibility, and cause the
-      // modal to open and close immediately
+      // via a click since this handler exists prior to visibility,
+      // causing the modal to open and close immediately
       if (!isOpen) {
         return true
       }

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -207,16 +207,23 @@ export const Modal = forwardRef<HTMLDivElement, ModalProps>(function Modal(
     // dismiss "this" modal. We let the useClickOutside in "that" modal to
     // dismiss it.
     (e: EventTarget) => {
+      // Only close if we're open.
+      // Closing when we're not open can cause a race condition when opened
+      // via a click since this handler exists prior to visibility, and cause the
+      // modal to open and close immediately
+      if (!isOpen) {
+        return true
+      }
       if (e instanceof Element) {
         const modalElement = findAncestor(e, `.${wrapperClass}`)
         if (!modalElement) {
-          return !isOpen
+          return false
         }
         const isModalWrapper = modalElement.classList.contains(wrapperClass)
         const isThisModalWrapper = modalElement.classList.contains(
           `${wrapperClass}-${id}`
         )
-        return isModalWrapper && !isThisModalWrapper && !isOpen
+        return isModalWrapper && !isThisModalWrapper
       }
       return false
     }

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -209,12 +209,14 @@ export const Modal = forwardRef<HTMLDivElement, ModalProps>(function Modal(
     (e: EventTarget) => {
       if (e instanceof Element) {
         const modalElement = findAncestor(e, `.${wrapperClass}`)
-        if (!modalElement) return false
+        if (!modalElement) {
+          return !isOpen
+        }
         const isModalWrapper = modalElement.classList.contains(wrapperClass)
         const isThisModalWrapper = modalElement.classList.contains(
           `${wrapperClass}-${id}`
         )
-        return isModalWrapper && !isThisModalWrapper
+        return isModalWrapper && !isThisModalWrapper && !isOpen
       }
       return false
     }

--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -33,8 +33,8 @@ export const useClickOutside = (
       onClick()
     }
 
-    document.addEventListener('mousedown', handleClick)
-    return () => document.removeEventListener('mousedown', handleClick)
+    document.addEventListener('click', handleClick)
+    return () => document.removeEventListener('click', handleClick)
   }, [onClick, ignoreClick])
 
   return ref


### PR DESCRIPTION
Using the 'mousedown' event causes unwanted dismissal prior to clicks happening in eg. popovers that spawn from the modal.